### PR TITLE
Fix docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /usr/src/app
 
 # Copy App Over
 COPY . /usr/src/app/
+COPY .env.example /usr/src/app/.env
 RUN npm install
 
 # Start the bot

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ client.on('message', message => {
 		return;
 	} else if (inputMatchesCommand(message.content, 'Disable')) {
 		message.channel.send((bEnabled) ? 
-			'PK-Bot disabled, re-enabled with "!PKEnable".' :
+			'PK-Bot disabled, re-enable with "!PKEnable".' :
 			'PK-Bot is already disabled.');
 		bEnabled = false;
 		return;

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -45,7 +45,7 @@ var processMessage = function(message) {
 			break;
 
 		default:
-			strMessage = `Command "${message.content} not recognized.`;
+			strMessage = `Command "${message.content}" not recognized.`;
 	}
 
 	// Save user data if needed


### PR DESCRIPTION
Originally when deploying the bot would fail to start because the file `.env` was missing. The dockerfile has been updated to fix this problem by copying over the example file.